### PR TITLE
Fix duplicated WWN when calling attach-disk script very quickly

### DIFF
--- a/scripts/attach-disk.sh
+++ b/scripts/attach-disk.sh
@@ -72,7 +72,7 @@ cat > $XML_FILE <<EOF
       <driver name='qemu' type='qcow2'/>
       <source file='$FILE'/>
       <target dev='$TARGET' bus='scsi'/>
-      <wwn>0x5000c50015$(date +%s | sha512sum | head -c 6)</wwn>
+      <wwn>0x5000c50015$(date +%N | sha512sum | head -c 6)</wwn>
     </disk>
 EOF
 


### PR DESCRIPTION
Use nano second as hash source.