### PR TITLE
Fallback rancherd to older version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,7 +116,7 @@ PROVISION_WORKER_CONFIG
 
 $provision_rancherd = <<-PROVISION_RANCHERD
 if [ "#{$workaround}" = "true" ]; then
-  curl -fL https://raw.githubusercontent.com/rancher/rancherd/harvester-dev/install.sh | sh -
+  curl -fL https://raw.githubusercontent.com/rancher/rancherd/harvester-dev/install.sh | INSTALL_RANCHERD_VERSION=v0.3.0-rc1 sh -
 else
   curl -fL https://raw.githubusercontent.com/rancher/rancherd/master/install.sh | sh -
 fi


### PR DESCRIPTION
Fallback rancherd to older version `v0.3.0-rc1` since after https://github.com/rancher/rancherd/commit/13285fa59ca51858f4c4dff4b19cc420ba381986, rancherd requires the `/usr/share/rancher/rancherd/config.yaml.d/91-harvester-bootstrap-repo.yaml` file to bootstrap successfully. While some of the environment don't have that file. For example, node-manager ci.